### PR TITLE
simplify num_builds logic

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -472,9 +472,8 @@ The following options are valid in version ``1`` (beside the generic options):
     implicit zero value from the y-axis.
   * ``y_axis_minimum``: Minimum y-axis value.
   * ``y_axis_maximum``: Maximum y-axis value.
-  * ``num_builds``: Number of builds back to show on this plot.
-    An empty string or not defined mean all builds.
-    Must not be "0", the default value is an empty string.
+  * ``num_builds``: Number of builds back to show on this plot (default: ``0``
+    which means all builds).
   * ``data_series``: a list of data series definitions comprised of:
 
     * ``data_file``: a path pattern relative to the workspace root to a file

--- a/ros_buildfarm/config/plot_config.py
+++ b/ros_buildfarm/config/plot_config.py
@@ -46,9 +46,8 @@ class PlotConfig:
         self.y_axis_minimum = data.get('y_axis_minimum', None)
         self.y_axis_maximum = data.get('y_axis_maximum', None)
 
-        self.num_builds = ""
-        if 'num_builds' in data:
-            self.num_builds = data['num_builds']
+        self.num_builds = data.get('num_builds', 0)
+        assert isinstance(self.num_builds, int)
 
         self.data_series = []
         if 'data_series' in data:

--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -27,7 +27,7 @@
 @[end for]@
           </series>
           <group>@(plot_group)</group>
-          <numBuilds>@(plot.num_builds)</numBuilds>
+          <numBuilds>@(plot.num_builds or '')</numBuilds>
           <csvFileName>@(plot.master_csv_name)</csvFileName>
           <csvLastModification>0</csvLastModification>
           <style>@(plot.style)</style>


### PR DESCRIPTION
How about simplifying the logic around `num_builds`.

The fact that the plugin doesn't accept `0` but wants an empty string could be hidden from the user. The config value is simply an `int` where `0` means *all builds*. In the XML a `0` is then mapped to an empty string to satisfy the plugin specific semantic.